### PR TITLE
Added -p option to mkdir.

### DIFF
--- a/tools/prepare_data/download_human3.6m.sh
+++ b/tools/prepare_data/download_human3.6m.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run this script on the root
-mkdir data/human
+mkdir -p data/human
 cd data/human
 
 # # Download H36M annotations

--- a/tools/prepare_data/download_kinetics.sh
+++ b/tools/prepare_data/download_kinetics.sh
@@ -2,6 +2,7 @@
 
 # run this script on the root of OpenSTL,
 # we provide this script according to https://github.com/cvdfoundation/kinetics-dataset
+mkdir -p data
 cd data
 
 

--- a/tools/prepare_data/download_kitticaltech.sh
+++ b/tools/prepare_data/download_kitticaltech.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run this script on the root
-mkdir data/kitti_hkl
+mkdir -p data/kitti_hkl
 cd data
 
 # you can download kitti and caltech datasets from Baidu Cloud `https://pan.baidu.com/s/1fudsBHyrf3nbt-7d42YWWg?pwd=kjfk`

--- a/tools/prepare_data/download_kth.sh
+++ b/tools/prepare_data/download_kth.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run this script on the root
-mkdir data/kth
+mkdir -p data/kth
 cd data/kth
 
 FORMAT='jpg'

--- a/tools/prepare_data/download_mfmnist.sh
+++ b/tools/prepare_data/download_mfmnist.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run this script on the root
-mkdir data/moving_fmnist
+mkdir -p data/moving_fmnist
 cd data/moving_fmnist
 
 # download fmnist and place them in `data/moving_fmnist/`

--- a/tools/prepare_data/download_mmnist.sh
+++ b/tools/prepare_data/download_mmnist.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run this script on the root
-mkdir data/moving_mnist
+mkdir -p data/moving_mnist
 cd data/moving_mnist
 
 # download mmnist and place them in `data/moving_mnist/`

--- a/tools/prepare_data/download_taxibj.sh
+++ b/tools/prepare_data/download_taxibj.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run this script on the root
-mkdir data/taxibj
+mkdir -p data/taxibj
 cd data/taxibj
 
 # download dataset.npz in `data/taxibj/`

--- a/tools/prepare_data/download_weatherbench.sh
+++ b/tools/prepare_data/download_weatherbench.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run this script on the root
-mkdir data/weather
+mkdir -p data/weather
 cd data/weather
 
 # down 5.625deg `2m_temperature` (32x64) and place them in `data/weather/` according to `https://github.com/pangeo-data/WeatherBench`


### PR DESCRIPTION
-p avoids errors on already existing folders and creates subfolders even when "data" directory didn't exist. This was blocking the mmnist example from the tutorial.