### PR TITLE
Changed config parser priority.

### DIFF
--- a/openstl/utils/parser.py
+++ b/openstl/utils/parser.py
@@ -78,7 +78,7 @@ def create_parser():
                         help='Whether to allow overwriting the provided config file with args')
 
     # Training parameters (optimizer)
-    parser.add_argument('--epoch', '-e', default=None, type=int, help='end epochs (default: 200)')
+    parser.add_argument('--epoch', '-e', default=200, type=int, help='end epochs (default: 200)')
     parser.add_argument('--log_step', default=1, type=int, help='Log interval by step')
     parser.add_argument('--opt', default='adam', type=str, metavar='OPTIMIZER',
                         help='Optimizer (default: "adam"')
@@ -97,9 +97,9 @@ def create_parser():
                         help='Check to early stop after this epoch')
 
     # Training parameters (scheduler)
-    parser.add_argument('--sched', default=None, type=str, metavar='SCHEDULER',
+    parser.add_argument('--sched', default='onecycle', type=str, metavar='SCHEDULER',
                         help='LR scheduler (default: "onecycle"')
-    parser.add_argument('--lr', default=None, type=float, help='Learning rate (default: 1e-3)')
+    parser.add_argument('--lr', default=1e-3, type=float, help='Learning rate (default: 1e-3)')
     parser.add_argument('--lr_k_decay', type=float, default=1.0,
                         help='learning rate k-decay for cosine/poly (default: 1.0)')
     parser.add_argument('--warmup_lr', type=float, default=1e-5, metavar='LR',

--- a/tools/train.py
+++ b/tools/train.py
@@ -22,7 +22,6 @@ if __name__ == '__main__':
     #   command line > f{args.method}.py > default from parser.py
     #first parser run to get the parameters to load f{args.method}.py 
     args = parser.parse_args()
-    config = args.__dict__
 
     #If we provided a config file, loads it. Else, tries to find one for
     #the method.
@@ -34,6 +33,11 @@ if __name__ == '__main__':
     
     #second parser run to get the final parameters
     args = parser.parse_args()
+    config = args.__dict__
+
+    if has_nni:
+        tuner_params = nni.get_next_parameter()
+        config.update(tuner_params)
 
     # set multi-process settings
     setup_multi_processes(config)


### PR DESCRIPTION
Config priority:
    command line > --config method.py > default from parser.py

First parser run to get the parameters to load f{args.method}.py 
If we provided a --config file, loads it. Else, tries to find one for the method.
Push the default values for this method to the parser Second parser run to get the final parameters.

I also changed back the default values to parser.py as there was no longer a need for the dict to stay in a separate file.