### PR TITLE
Add einops dependency

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,7 @@
 dask
 decord
 future
+einops
 fvcore
 hickle
 lpips


### PR DESCRIPTION
Required by `openstl/modules/wast_modules.py`.