### PR TITLE
Update wast_modules.py

### DIFF
--- a/openstl/modules/wast_modules.py
+++ b/openstl/modules/wast_modules.py
@@ -7,7 +7,7 @@ from timm.layers import DropPath, activations
 from timm.models._efficientnet_blocks import SqueezeExcite, InvertedResidual
 
 # version adaptation for PyTorch > 1.7.1
-IS_HIGH_VERSION = tuple(map(int, torch.__version__.split('+')[0].split('.'))) > (1, 7, 1)
+IS_HIGH_VERSION = tuple(map(lambda x: int(float(x)), torch.__version__.split('+')[0].split('.')[0:3])) > (1, 7, 1)
 if IS_HIGH_VERSION:
     import torch.fft
 


### PR DESCRIPTION
Hi,

A minor one. I use Nightly PyTorch version and from the command `torch.__version__.split('+')[0].split('.')` at line 10 of openstl/modules/wast_modules.py my output is `['2', '6', '0', 'dev20241022']`. However, there is a problem converting `'dev20241022'` to integer using `int`. Moreover, this is compared to `(1, 7, 1)`. So, using only the first three list items with `torch.__version__.split('+')[0].split('.')[0:3]` solved my issue.

Thanks.