### PR TITLE
Fix: Corrected OneCycleLR scheduler step calculation

### DIFF
--- a/openstl/core/optim_scheduler.py
+++ b/openstl/core/optim_scheduler.py
@@ -136,7 +136,7 @@ def get_optim_scheduler(args, epoch, model, steps_per_epoch):
         lr_scheduler = optim.lr_scheduler.OneCycleLR(
             optimizer,
             max_lr=args.lr,
-            total_steps=total_steps // len(args.gpus),
+            total_steps=total_steps,
             final_div_factor=getattr(args, 'final_div_factor', 1e4))
         by_epoch = False
     elif sched_lower == 'cosine':


### PR DESCRIPTION
This change prevents scheduler step limit errors in distributed training scenarios.